### PR TITLE
Allow safari incognito to fail silently and load page properly.

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -166,19 +166,22 @@ function loadBundlesSync(lang, langBundles) {
   });
 }
 
+// Since Safari doesn't allow localStorage setter/getter functions in incognito mode
+// we need to conditionally check that localStorage is available for setCache and getCache
+// https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API#Private_Browsing_Incognito_modes
 function setCache(lang, bundles) {
-  if (store) {
+  try {
     store.setItem(`${ storePrefix }.${ lang }`, JSON.stringify(bundles || {}));
-  } else {
+  } catch(e) {
     CACHE[lang] = bundles;
   }
 }
 
 function getCache(lang) {
-  if (store) {
+  try {
     const item = store.getItem(`${ storePrefix }.${ lang }`);
     return JSON.parse(item || '{}');
-  } else {
+  } catch(e) {
     return CACHE[lang];
   }
 }


### PR DESCRIPTION
[#151812339]
https://www.pivotaltracker.com/story/show/151812339

Currently the commercial app will fail to load in Safari incognito and throw the following error `QuotaExceededError (DOM Exception 22): The quota has been exceeded.` because Safari can't set/get anything to sessionStorage in incognito mode. This fix allows the page to load and the sessionStorage error will fail silently with a warning.