### PR TITLE
Update createClass call

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^0.14.7 || ^15.0.0"
   },
   "dependencies": {
+    "create-react-class": "^15.6.3",
     "fbemitter": "^2.1.1",
     "prop-types": "^15.6.0"
   },

--- a/src/components.js
+++ b/src/components.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import CreateReactClass from 'create-react-class';
 
 import lib from './lib';
 
@@ -112,7 +113,7 @@ const VALID_TAGS = [
   'label', 'option',
 ];
 VALID_TAGS.forEach((tagName) => {
-  i18n[tagName] = React.createClass(Object.assign({
+  i18n[tagName] = CreateReactClass(Object.assign({
     getInitialState: getInitialState(tagName),
     propTypes: PROP_TYPES[tagName] || DEFAULT_PROP_TYPES,
   }, DEFAULT_ELEM));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1353,6 +1353,14 @@ create-react-class@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-class@^15.6.3:
+  version "15.6.3"
+  resolved "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"


### PR DESCRIPTION
Swapping out the deprecated use of `React.createClass` with `createReactClass` for the commercial React 16 upgrade.