### PR TITLE
Release v1.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coverhound/react-i18n",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
I ran `np` but the publishing of the package step failed. npm still shows that v1.7.3 was released though, so I'm updating the package.json to reflect the new version.